### PR TITLE
Filter heatmap by channel

### DIFF
--- a/__tests__/fixtures/guilds.fixture.ts
+++ b/__tests__/fixtures/guilds.fixture.ts
@@ -80,6 +80,33 @@ export const guildFour = {
     icon: 'IconFour'
 }
 
+export const guildFive = {
+    _id: new Types.ObjectId(),
+    guildId: "681946187490000999",
+    user: userOne.discordId,
+    name: 'guildFive',
+    isDisconnected: false,
+    isInProgress: true,
+    icon: 'IconFive',
+    selectedChannels: [
+        {
+            channelId: '915944557605163008',
+            channelName: 'one'
+        },
+        {
+            channelId: '920707473369878589',
+            channelName: 'two'
+        },
+        {
+            channelId: '915917066496774165',
+            channelName: 'three'
+        },
+    ]
+}
+
+
 export const insertGuilds = async function <Type>(guilds: Array<Type>) {
     await Guild.insertMany(guilds.map((guild) => (guild)));
 };
+
+

--- a/__tests__/integration/guild.test.ts
+++ b/__tests__/integration/guild.test.ts
@@ -5,7 +5,7 @@ import app from '../../src/app';
 import setupTestDB from '../utils/setupTestDB';
 import { userOne, insertUsers } from '../fixtures/user.fixture';
 import { userOneAccessToken } from '../fixtures/token.fixture';
-import { discordResponseGuildOne, guildOne, guildTwo, guildThree, guildFour, insertGuilds } from '../fixtures/guilds.fixture';
+import { discordResponseGuildOne, guildOne, guildTwo, guildThree, guildFour, guildFive, insertGuilds } from '../fixtures/guilds.fixture';
 import { discordResponseChannels, discordResponseChannelOne } from '../fixtures/channels.fixture';
 import { IGuildUpdateBody } from '../../src/interfaces/guild.interface';
 import { guildService, authService, userService } from '../../src/services';
@@ -17,11 +17,11 @@ describe('Guild routes', () => {
 
     describe('GET /api/v1/guilds/:guildId/channels', () => {
         beforeEach(() => {
-            guildService.getGuildChannelsFromDiscordJS = jest.fn().mockReturnValue(discordResponseChannels);
+            guildService.getChannelsFromDiscordJS = jest.fn().mockReturnValue(discordResponseChannels);
             guildService.isBotAddedToGuild = jest.fn().mockReturnValue(true);
         });
 
-        test('should return 200 and array of channels of guild', async () => {
+        test('should return 200 and array of channels of the guild', async () => {
             await insertUsers([userOne]);
             await insertGuilds([guildOne]);
             const res = await request(app)
@@ -34,7 +34,6 @@ describe('Guild routes', () => {
             expect(res.body[0].subChannels).toHaveLength(2);
             expect(res.body[1].subChannels).toHaveLength(2);
             expect(res.body[2].subChannels).toHaveLength(2);
-
 
             expect(res.body[0]).toEqual({
                 id: "915914985140531241",
@@ -52,8 +51,10 @@ describe('Guild routes', () => {
                     parent_id: "915914985140531241",
                     guild_id: "915914985140531240",
                     canReadMessageHistoryAndViewChannel: true
-                },]
+                }]
             });
+
+
             expect(res.body[1]).toEqual({
                 id: "928623723190292520",
                 title: "┏━┫WELCOME┣━━━━┓",
@@ -70,7 +71,7 @@ describe('Guild routes', () => {
                     parent_id: "928623723190292520",
                     guild_id: "915914985140531240",
                     canReadMessageHistoryAndViewChannel: true
-                },]
+                }]
             });
             expect(res.body[2]).toEqual({
                 id: "928627624585072640",
@@ -114,6 +115,98 @@ describe('Guild routes', () => {
             await insertUsers([userOne]);
             await request(app)
                 .get(`/api/v1/guilds/${discordResponseGuildOne.id}/channels`)
+                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .send()
+                .expect(httpStatus.BAD_REQUEST);
+
+        })
+    })
+
+    describe('GET /api/v1/guilds/:guildId/selected-channels', () => {
+        beforeEach(() => {
+            guildService.getChannelsFromDiscordJS = jest.fn().mockReturnValue(discordResponseChannels);
+            guildService.isBotAddedToGuild = jest.fn().mockReturnValue(true);
+        });
+
+        test('should return 200 and array of selected channels of the guild', async () => {
+            await insertUsers([userOne]);
+            await insertGuilds([guildFive]);
+            const res = await request(app)
+                .get(`/api/v1/guilds/${guildFive.guildId}/selected-channels`)
+                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .send()
+                .expect(httpStatus.OK);
+
+            expect(res.body).toHaveLength(2);
+            expect(res.body[0].subChannels).toHaveLength(2);
+            expect(res.body[1].subChannels).toHaveLength(1);
+
+
+            expect(res.body[0]).toEqual({
+                id: "915914985140531241",
+                title: "┏━┫COMMUNITY┣━━━━┓",
+                subChannels: [{
+                    id: "915944557605163008",
+                    name: "💬・general-chat",
+                    parent_id: "915914985140531241",
+                    guild_id: "915914985140531240",
+                    canReadMessageHistoryAndViewChannel: true
+                },
+                {
+                    id: "920707473369878589",
+                    name: "📖・learning-together",
+                    parent_id: "915914985140531241",
+                    guild_id: "915914985140531240",
+                    canReadMessageHistoryAndViewChannel: true
+                },]
+            });
+            expect(res.body[1]).toEqual({
+                id: "928623723190292520",
+                title: "┏━┫WELCOME┣━━━━┓",
+                subChannels: [{
+                    id: "915917066496774165",
+                    name: "👋・introductions",
+                    parent_id: "928623723190292520",
+                    guild_id: "915914985140531240",
+                    canReadMessageHistoryAndViewChannel: true
+                }]
+            });
+
+        })
+
+        test('should return 200 and empty array if selected channels of the guild is empty', async () => {
+            await insertUsers([userOne]);
+            await insertGuilds([guildOne]);
+            const res = await request(app)
+                .get(`/api/v1/guilds/${guildOne.guildId}/selected-channels`)
+                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .send()
+                .expect(httpStatus.OK);
+
+            expect(res.body).toHaveLength(0);
+        })
+
+        test('should return 400 if bot is not added to guild', async () => {
+            guildService.isBotAddedToGuild = jest.fn().mockReturnValue(false);
+            await insertUsers([userOne]);
+            await request(app)
+                .get(`/api/v1/guilds/${guildFive.guildId}/selected-channels`)
+                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .send()
+                .expect(httpStatus.BAD_REQUEST);
+        })
+        test('should return 401 if access token is missing', async () => {
+            await insertUsers([userOne]);
+            await request(app)
+                .get(`/api/v1/guilds/${guildFive.guildId}/selected-channels`)
+                .send()
+                .expect(httpStatus.UNAUTHORIZED);
+        })
+        test('should return 400 if can not fetch guild channels', async () => {
+            guildService.isBotAddedToGuild = jest.fn().mockReturnValue(false);
+            await insertUsers([userOne]);
+            await request(app)
+                .get(`/api/v1/guilds/${guildFive.guildId}/selected-channels`)
                 .set('Authorization', `Bearer ${userOneAccessToken}`)
                 .send()
                 .expect(httpStatus.BAD_REQUEST);

--- a/__tests__/integration/heatmap.test.ts
+++ b/__tests__/integration/heatmap.test.ts
@@ -27,7 +27,7 @@ describe('Heatmap routes', () => {
                 startDate: new Date("2023-01-01"),
                 endDate: new Date("2023-01-31"),
                 timeZone: "Universal", // 0
-                channelIds: []
+                channelIds: ["1012430565959553148", "1012430565959553211", "1012430565959553149"]
 
             };
         });
@@ -115,6 +115,26 @@ describe('Heatmap routes', () => {
 
             expect(res.body[27]).toEqual([1, 4, 0])
             expect(res.body[47]).toEqual([1, 24, 0])
+        })
+
+        test('should return 200 and empty chart data if channelIds is empty req data is ok', async () => {
+            await insertUsers([userOne]);
+            await insertGuilds([guildOne]);
+
+            await heatmapService.createHeatMaps(connection, [heatmapOne, heatmapTwo, heatmapThirteen]);
+            requestBody.startDate = new Date("2023-01-20");
+            requestBody.endDate = new Date("2023-01-22");
+            requestBody.channelIds = []
+            const res = await request(app)
+                .post(`/api/v1/heatmaps/${guildOne.guildId}/heatmap-chart`)
+                .set('Authorization', `Bearer ${userOneAccessToken}`)
+                .send(requestBody)
+                .expect(httpStatus.OK);
+
+            expect(res.body.length).toBe(168);
+
+            const valuePattern = expect.arrayContaining([expect.anything(), expect.anything(), 0]);
+            expect(res.body).toEqual(expect.arrayContaining(Array(168).fill(valuePattern)));
         })
 
         test('should return 401 if access token is missing', async () => {

--- a/src/controllers/heatmap.controller.ts
+++ b/src/controllers/heatmap.controller.ts
@@ -11,6 +11,9 @@ const heatmapChart = catchAsync(async function (req: IAuthRequest, res: Response
     if (!await guildService.getGuild({ guildId: req.params.guildId, user: req.user.discordId })) {
         throw new ApiError(httpStatus.NOT_FOUND, 'Guild not found');
     }
+    if (req.body.channelIds.length === 0) {
+        return res.send(charts.fillHeatmapChart([]))
+    }
     const connection = databaseService.connectionFactory(req.params.guildId, config.mongoose.botURL);
     let heatmaps = await heatmapService.getHeatmapChart(connection, req.body);
     const timeZoneOffset = parseInt(moment().tz(req.body.timeZone).format('Z'));

--- a/src/docs/guild.doc.yml
+++ b/src/docs/guild.doc.yml
@@ -216,7 +216,7 @@ paths:
     get:
       tags:
         - [Guild]
-      summary: Get guild's channels by guildId
+      summary: Get channels by guildId
       description: Used the discordjs library. for each channel we will check the bot has the Read message history and view channel permission or not .categories with zero subChannels will remove from the response
       security:
         - bearerAuth: []
@@ -274,6 +274,67 @@ paths:
           description: Can not fetch from discord API
           $ref: "#/components/responses/Can_Not_Fetch_From_Discord_API"
 
+  /api/v1/guilds/{guildId}/selected-channels:
+    get:
+      tags:
+        - [Guild]
+      summary: Get selected channels by guildId
+      description: Used the discordjs library.it will filter the channel list base on the selected channel of the guild.categories with zero subChannels will remove from the response
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: guildId
+          required: true
+          schema:
+            type: string
+          description: Guild Id
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: 
+                  type: object
+                  properties: 
+                    id: 
+                      type: string
+                      format: Snowflake
+                    title: 
+                      type: string
+                    subChannels: 
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id: 
+                            type: Snowflake
+                          name: 
+                            type: string
+                          canReadMessageHistoryAndViewChannel: 
+                            type: boolean
+                          parent_id: 
+                            type: Snowflake
+                example:
+                    id: "80351110224678914"
+                    title: "channel B"
+                    subChannels: [{
+                        id: "80351110224678912",
+                        name: "channel C",
+                        parent_id: "80351110224678914",
+                        canReadMessageHistoryAndViewChannel: true,
+                      }]
+        "400":
+          description: Bad Request
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          description: Unauthorized
+          $ref: "#/components/responses/Unauthorized"
+        "590":
+          description: Can not fetch from discord API
+          $ref: "#/components/responses/Can_Not_Fetch_From_Discord_API"
 
 
 

--- a/src/interfaces/guild.interface.ts
+++ b/src/interfaces/guild.interface.ts
@@ -20,3 +20,12 @@ export interface IPermissionOverwrite {
     allow_new: string,
     deny_new: string
 }
+
+
+export interface ICustomChannel {
+    id: string;
+    name: string;
+    parent_id: string;
+    guild_id: string;
+    canReadMessageHistoryAndViewChannel: boolean;
+}

--- a/src/routes/v1/guilds.route.ts
+++ b/src/routes/v1/guilds.route.ts
@@ -12,7 +12,9 @@ router.get('/', auth(), validate(guildValidation.getGuilds), guildController.get
 router.get('/connect', guildController.connectGuild);
 router.get('/connect/callback', guildController.connectGuildCallback);
 
-router.get('/:guildId/channels', auth(), validate(guildValidation.getGuildChannels), guildController.getGuildChannels);
+router.get('/:guildId/channels', auth(), validate(guildValidation.getChannels), guildController.getChannels);
+router.get('/:guildId/selected-channels', auth(), validate(guildValidation.getSelectedChannels), guildController.getSelectedChannels);
+
 router.post('/:guildId/disconnect', auth(), validate(guildValidation.disconnectGuild), guildController.disconnectGuild);
 
 router.route('/:guildId')

--- a/src/services/guild.service.ts
+++ b/src/services/guild.service.ts
@@ -107,7 +107,7 @@ async function getGuildFromDiscordAPI(guildId: Snowflake) {
  * @param {Snowflake} guildId
  * @returns {Promise<Array<IDiscordGuild>>}
  */
-async function getGuildChannels(guildId: Snowflake) {
+async function getChannels(guildId: Snowflake) {
     try {
         const response = await fetch(`https://discord.com/api/guilds/${guildId}/channels?`, {
             method: 'GET',
@@ -131,7 +131,7 @@ async function getGuildChannels(guildId: Snowflake) {
  * @param {Snowflake} guildId
  * @returns {Promise<Array<IDiscordChannel>>}
  */
-async function getGuildChannelsFromDiscordJS(guildId: Snowflake) {
+async function getChannelsFromDiscordJS(guildId: Snowflake) {
     try {
         const client = await getDiscordClient();
         const guild = await client.guilds.fetch(guildId);
@@ -196,7 +196,7 @@ async function getGuildMemberFromDiscordAPI(guildId: Snowflake, discordId: Snowf
 export default {
     createGuild,
     getGuildByGuildId,
-    getGuildChannels,
+    getChannels,
     updateGuild,
     isBotAddedToGuild,
     getGuild,
@@ -204,6 +204,6 @@ export default {
     queryGuilds,
     deleteGuild,
     getGuildMemberFromDiscordAPI,
-    getGuildChannelsFromDiscordJS
+    getChannelsFromDiscordJS
 }
 

--- a/src/validations/guild.validation.ts
+++ b/src/validations/guild.validation.ts
@@ -47,14 +47,21 @@ const getGuildFromDiscordAPI = {
 
 
 
-const getGuildChannels = {
+const getChannels = {
+    params: Joi.object().required().keys({
+        guildId: Joi.string().required()
+    })
+};
+
+const getSelectedChannels = {
     params: Joi.object().required().keys({
         guildId: Joi.string().required()
     })
 };
 
 export default {
-    getGuildChannels,
+    getSelectedChannels,
+    getChannels,
     updateGuild,
     getGuild,
     getGuildFromDiscordAPI,


### PR DESCRIPTION
https://www.notion.so/Product-Roadmap-531f72f0dc6e43f697ba60e02fbf3fd3?p=005943fdec284d5583deaa2844b989f3&pm=s

https://github.com/RnDAO/tc-serverComm/issues/63

**changes** :
 - Implement a new API to get a list of channels (use case: filter the heatmaps)
 - Enable users to filter the heatmap chart based on channels
 - Synchronize the heatmap chart's response with the selected channels of the server (e.g., if the selected channel list contains channels A and B, users can only filter the heatmap based on channels A and B).
 

